### PR TITLE
Add historical data client wrapper

### DIFF
--- a/test/test_historical_data_client.py
+++ b/test/test_historical_data_client.py
@@ -1,0 +1,53 @@
+import sys
+import types
+import unittest
+from datetime import date
+from unittest.mock import MagicMock
+
+# The package imports a number of optional dependencies during initialisation
+# (websocket and protobuf based streamers). Those packages are not available in
+# the test environment, so we register lightweight stubs before importing the
+# client package to avoid import errors.
+sys.modules.setdefault("websocket", MagicMock())
+
+feeder_pkg = types.ModuleType("feeder")
+sys.modules["upstox_client.feeder"] = feeder_pkg
+
+md_stub = types.ModuleType("market_data_streamer")
+md_stub.MarketDataStreamer = object
+sys.modules["upstox_client.feeder.market_data_streamer"] = md_stub
+
+md_v3_stub = types.ModuleType("market_data_streamer_v3")
+md_v3_stub.MarketDataStreamerV3 = object
+sys.modules["upstox_client.feeder.market_data_streamer_v3"] = md_v3_stub
+
+portfolio_stub = types.ModuleType("portfolio_data_streamer")
+portfolio_stub.PortfolioDataStreamer = object
+sys.modules["upstox_client.feeder.portfolio_data_streamer"] = portfolio_stub
+
+from upstox_client.historical_client import HistoricalDataClient
+
+
+class TestHistoricalDataClient(unittest.TestCase):
+    def test_get_historical_data_formats_dates_and_calls_api(self):
+        history_api = MagicMock()
+        client = HistoricalDataClient(history_api=history_api)
+
+        client.get_historical_data(
+            "NSE_EQ|TEST",
+            "day",
+            date(2024, 1, 1),
+            date(2024, 1, 31),
+        )
+
+        history_api.get_historical_candle_data1.assert_called_once_with(
+            "NSE_EQ|TEST",
+            "day",
+            "2024-01-31",
+            "2024-01-01",
+            "v2",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/upstox_client/__init__.py
+++ b/upstox_client/__init__.py
@@ -31,6 +31,7 @@ from upstox_client.api.trade_profit_and_loss_api import TradeProfitAndLossApi
 from upstox_client.api.user_api import UserApi
 from upstox_client.api.websocket_api import WebsocketApi
 from upstox_client.api.order_controller_v_3_api import OrderApiV3
+from upstox_client.historical_client import HistoricalDataClient
 # import websocket interfaces into sdk package
 from upstox_client.feeder.market_data_streamer import MarketDataStreamer
 from upstox_client.feeder.market_data_streamer_v3 import MarketDataStreamerV3

--- a/upstox_client/historical_client.py
+++ b/upstox_client/historical_client.py
@@ -1,0 +1,84 @@
+"""Utilities for fetching historical candle data.
+
+This module provides a small wrapper around :class:`~upstox_client.api.history_api.HistoryApi`
+that exposes a simpler interface for fetching historical candle data.
+
+Example
+-------
+
+>>> from upstox_client import ApiClient, Configuration
+>>> from upstox_client.historical_client import HistoricalDataClient
+>>> config = Configuration()
+>>> config.access_token = "ACCESS_TOKEN"
+>>> client = HistoricalDataClient(ApiClient(config))
+>>> candles = client.get_historical_data("NSE_EQ|INE669E01016", "day", "2024-01-01", "2024-01-31")
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Optional, Union
+
+from .api.history_api import HistoryApi
+from .api_client import ApiClient
+
+DateType = Union[str, date, datetime]
+
+
+class HistoricalDataClient:
+    """Simple client for the historical candle data endpoints."""
+
+    def __init__(self, api_client: Optional[ApiClient] = None, api_version: str = "v2", history_api: Optional[HistoryApi] = None):
+        """Create a new :class:`HistoricalDataClient` instance.
+
+        Parameters
+        ----------
+        api_client:
+            Optional :class:`~upstox_client.api_client.ApiClient` instance. If not
+            provided a default instance will be created.
+        api_version:
+            API version header to be used when making requests. Defaults to ``"v2"``.
+        history_api:
+            Internal use only. Allows injecting a custom :class:`HistoryApi` instance,
+            primarily for testing.
+        """
+
+        self._history_api = history_api or HistoryApi(api_client or ApiClient())
+        self._api_version = api_version
+
+    @staticmethod
+    def _format_date(value: DateType) -> str:
+        """Format ``value`` into the ``YYYY-MM-DD`` string expected by the API."""
+        if isinstance(value, (date, datetime)):
+            return value.strftime("%Y-%m-%d")
+        return str(value)
+
+    def get_historical_data(self, instrument_key: str, interval: str, from_date: DateType, to_date: DateType):
+        """Fetch historical candle data for ``instrument_key``.
+
+        Parameters
+        ----------
+        instrument_key:
+            Instrument identifier.
+        interval:
+            Interval between candles. For example ``"day"`` or ``"1minute"``.
+        from_date:
+            Start date of the range (inclusive). Accepts ``datetime.date``, ``datetime.datetime``
+            or an ISO formatted string ``YYYY-MM-DD``.
+        to_date:
+            End date of the range (inclusive). Accepts the same formats as ``from_date``.
+
+        Returns
+        -------
+        :class:`~upstox_client.models.get_historical_candle_response.GetHistoricalCandleResponse`
+            Response object returned by the underlying API client.
+        """
+        from_str = self._format_date(from_date)
+        to_str = self._format_date(to_date)
+        return self._history_api.get_historical_candle_data1(
+            instrument_key,
+            interval,
+            to_str,
+            from_str,
+            self._api_version,
+        )


### PR DESCRIPTION
## Summary
- add `HistoricalDataClient` helper for historical candles
- export new client in package init
- cover date formatting and API invocation with unit test

## Testing
- `pytest`
- `pytest test/test_historical_data_client.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc3421a6788329bd42442761391158